### PR TITLE
Исправлен баг в html

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
         <label><select name="housing_price" id="housing_price" class="tokyo__filter">
           <option value="middle" selected>10000 - 50000&#x20bd;</option>
           <option value="low">до 10000&#x20bd;</option>
-          <option value="hight">от 50000&#x20bd;</option>
+          <option value="high">от 50000&#x20bd;</option>
         </select></label>
         <label><select name="housing_room-number" id="housing_room-number" class="tokyo__filter">
           <option value="any" selected>Любое число комнат</option>


### PR DESCRIPTION
Исправлена опечатка в исходном html ("hight" вместо "high"), из-за которого не работал фильтр с максимальным значением цены